### PR TITLE
v0.6.2-zhou -> v0.6.2

### DIFF
--- a/src/main/java/edu/pitt/dbmi/ccd/db/repository/DataFileRepository.java
+++ b/src/main/java/edu/pitt/dbmi/ccd/db/repository/DataFileRepository.java
@@ -46,4 +46,6 @@ public interface DataFileRepository extends JpaRepository<DataFile, Long> {
 
     public List<DataFile> findByUserAccounts(Set<UserAccount> userAccounts);
 
+    public DataFile findByIdAndUserAccounts(Long id, Set<UserAccount> userAccounts);
+
 }

--- a/src/main/java/edu/pitt/dbmi/ccd/db/service/DataFileService.java
+++ b/src/main/java/edu/pitt/dbmi/ccd/db/service/DataFileService.java
@@ -73,6 +73,10 @@ public class DataFileService {
         return dataFileRepository.findByIdAndUserAccounts(id, Collections.singleton(userAccount));
     }
 
+    public List<DataFile> findByUserAccount(UserAccount userAccount) {
+        return dataFileRepository.findByUserAccounts(Collections.singleton(userAccount));
+    }
+
     public DataFile findByAbsolutePathAndName(String absolutePath, String name) {
         return dataFileRepository.findByAbsolutePathAndName(absolutePath, name);
     }

--- a/src/main/java/edu/pitt/dbmi/ccd/db/service/DataFileService.java
+++ b/src/main/java/edu/pitt/dbmi/ccd/db/service/DataFileService.java
@@ -23,6 +23,7 @@ import edu.pitt.dbmi.ccd.db.entity.DataFileInfo;
 import edu.pitt.dbmi.ccd.db.entity.UserAccount;
 import edu.pitt.dbmi.ccd.db.repository.DataFileInfoRepository;
 import edu.pitt.dbmi.ccd.db.repository.DataFileRepository;
+import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Set;
@@ -66,6 +67,10 @@ public class DataFileService {
 
     public List<DataFile> findByUserAccounts(Set<UserAccount> userAccounts) {
         return dataFileRepository.findByUserAccounts(userAccounts);
+    }
+
+    public DataFile findByIdAndUserAccount(Long id, UserAccount userAccount) {
+        return dataFileRepository.findByIdAndUserAccounts(id, Collections.singleton(userAccount));
     }
 
     public DataFile findByAbsolutePathAndName(String absolutePath, String name) {


### PR DESCRIPTION
This pull request is created to add two more DataFileService methods:

public DataFile findByIdAndUserAccount(Long id, UserAccount userAccount) {}

public List findByUserAccount(UserAccount userAccount) {}

As a result, we also added a new method in DataFileRepository:

public DataFile findByIdAndUserAccounts(Long id, Set userAccounts)
And these methods will be used by the causal-rest-api.

@kvb2univpitt please review and merge if things look good.
