### PR TITLE
Added JobQueueInfo.findByIdAndUserAccount() and DataFile.findById()

### DIFF
--- a/src/main/java/edu/pitt/dbmi/ccd/db/repository/DataFileRepository.java
+++ b/src/main/java/edu/pitt/dbmi/ccd/db/repository/DataFileRepository.java
@@ -35,6 +35,8 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface DataFileRepository extends JpaRepository<DataFile, Long> {
 
+    public DataFile findById(Long id);
+
     public DataFile findByName(String name);
 
     public List<DataFile> findByAbsolutePath(String absolutePath);

--- a/src/main/java/edu/pitt/dbmi/ccd/db/repository/JobQueueInfoRepository.java
+++ b/src/main/java/edu/pitt/dbmi/ccd/db/repository/JobQueueInfoRepository.java
@@ -36,6 +36,8 @@ public interface JobQueueInfoRepository extends JpaRepository<JobQueueInfo, Long
 
     public JobQueueInfo findByPid(Long pid);
 
+    public JobQueueInfo findByIdAndUserAccounts(Long id, Set<UserAccount> userAccounts);
+
     public List<JobQueueInfo> findByStatus(int status);
 
     public List<JobQueueInfo> findByUserAccounts(Set<UserAccount> userAccounts);

--- a/src/main/java/edu/pitt/dbmi/ccd/db/service/DataFileService.java
+++ b/src/main/java/edu/pitt/dbmi/ccd/db/service/DataFileService.java
@@ -57,6 +57,10 @@ public class DataFileService {
         this.dataFileInfoRepository = dataFileInfoRepository;
     }
 
+    public DataFile findById(Long id) {
+        return dataFileRepository.findById(id);
+    }
+
     public DataFile findByName(String name) {
         return dataFileRepository.findByName(name);
     }

--- a/src/main/java/edu/pitt/dbmi/ccd/db/service/JobQueueInfoService.java
+++ b/src/main/java/edu/pitt/dbmi/ccd/db/service/JobQueueInfoService.java
@@ -21,6 +21,7 @@ package edu.pitt.dbmi.ccd.db.service;
 import edu.pitt.dbmi.ccd.db.entity.JobQueueInfo;
 import edu.pitt.dbmi.ccd.db.entity.UserAccount;
 import edu.pitt.dbmi.ccd.db.repository.JobQueueInfoRepository;
+import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 import org.slf4j.Logger;
@@ -106,6 +107,10 @@ public class JobQueueInfoService {
 
     public JobQueueInfo findOne(Long id) {
         return jobQueueInfoRepository.findOne(id);
+    }
+
+    public JobQueueInfo findByIdAndUseraccount(Long id, UserAccount userAccount) {
+        return jobQueueInfoRepository.findByIdAndUserAccounts(id, Collections.singleton(userAccount));
     }
 
     public List<JobQueueInfo> findByUserAccounts(Set<UserAccount> userAccounts) {


### PR DESCRIPTION
@kvb2univpitt I added this new function in order to allow API users to cancel a job by  given job ID. I was using `findOne()` at https://github.com/bd2kccd/ccd-db/blob/master/src/main/java/edu/pitt/dbmi/ccd/db/service/JobQueueInfoService.java#L107  earlier then realized that this method doesn't check if the job id is associated with that user. In Causal web, the user can only see running jobs that he submitted, so there's no concern with using this `findOne()`. But in the API world, we have to make sure the job to be canceled was created by that user.

Also added `DataFile.findById()`. This will be used to get the file delimiter when run the algorithm.
